### PR TITLE
allowing for http api to be used for fleet provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin/*
+terraform-provider-fleet
+

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ provider "fleet" {
 ```
 provider "fleet" {
   driver = "api"
-  endpoint = "http://192.168.0.1:4001"
+  endpoint = "http://192.168.0.1:8080"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ EX:
 provider "fleet" {
   driver = "etcd"
   endpoint = "http://192.168.0.1:4001"
+  // etcd_key_prefix can be ommited to use the default value
+  etcd_key_prefix = "/_some/_weird/etcd/prefix"
+  // connection_retries defaults to 12
+  connection_retries = 9000
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,37 @@ A plugin for Terraform enabling it to manipulate
 
 ## Usage
 
+This terraform plugin supports basic connections to the ETCD endpoint,
+the HTTP API endpoint, and over SSH
+
+There is minimal configuration currently supported so the ETCD and API clients
+are attempting to connect directly without SSL
+
+The configuration value 'driver' defaults to 'tunnel' but can be configured with:
+ * etcd
+ * api
+
+EX:
+
+```
+provider "fleet" {
+  driver = "etcd"
+  endpoint = "http://192.168.0.1:4001"
+}
+```
+
+```
+provider "fleet" {
+  driver = "api"
+  endpoint = "http://192.168.0.1:4001"
+}
+```
+
 There is only one resource: `fleet_unit`. Here is the first example from
 [the Fleet introduction][3], transcribed to Terraform:
 
     provider "fleet" {
-        tunnel_address = "IP_OR_HOSTNAME_OF_A_COREOS_HOST"
+        endpoint = "IP_OR_HOSTNAME_OF_A_COREOS_HOST"
     }
 
     resource "fleet_unit" "myapp" {

--- a/provider.go
+++ b/provider.go
@@ -186,7 +186,7 @@ func Provider() terraform.ResourceProvider {
 				Optional: true,
 				Default:  12,
 			},
-			"etc_key_prefix": &schema.Schema{
+			"etcd_key_prefix": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Default: "/_coreos.com/fleet/",
@@ -204,6 +204,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	retries := d.Get("connection_retries").(int)
 	driver := d.Get("driver").(string)
 	endpoint := d.Get("endpoint").(string)
-	etcKeyPrefix := d.Get("etc_key_prefix").(string)
+	etcKeyPrefix := d.Get("etcd_key_prefix").(string)
 	return getAPI(driver, endpoint, retries, etcKeyPrefix)
 }

--- a/provider.go
+++ b/provider.go
@@ -108,7 +108,7 @@ func getTunnelClient(driverEndpoint string, tunnelEndpoint string, maxRetries in
 	log.Printf("Using Fleet Tunnel connection for requests")
 
 	getSSHClient := func() (interface{}, error) {
-		return ssh.NewSSHClient("core", tunnelEndpoint, nil, false, defaultTimeout)
+		return ssh.NewSSHClient("core", driverEndpoint, nil, false, defaultTimeout)
 	}
 
 	result, err := retry(getSSHClient, maxRetries)
@@ -118,7 +118,7 @@ func getTunnelClient(driverEndpoint string, tunnelEndpoint string, maxRetries in
 	sshClient := result.(*ssh.SSHForwardingClient)
 
 	dial := func(string, string) (net.Conn, error) {
-		cmd := fmt.Sprintf("fleetctl fd-forward %s", driverEndpoint)
+		cmd := fmt.Sprintf("fleetctl fd-forward %s", tunnelEndpoint)
 		return ssh.DialCommand(sshClient, cmd)
 	}
 

--- a/provider.go
+++ b/provider.go
@@ -33,15 +33,17 @@ func retry(f func() (interface{}, error), maxRetries int) (interface{}, error) {
 
 // getAPI returns an API to Fleet.
 func getAPI(driver string, driverEndpoint string, hostAddr string, maxRetries int) (client.API, error) {
-	if hostAddr == "" {
-		return nullAPI{}, nil
-	}
+
 	var endpoint *url.URL
 	var dial func(network, addr string) (net.Conn, error)
 	switch strings.ToLower(driver) {
 	case "api":
-		dial = net.Dial
+		dial = nil
 	case "tunnel":
+		if hostAddr == "" {
+			return nullAPI{}, nil
+		}
+		
 		getSSHClient := func() (interface{}, error) {
 			return ssh.NewSSHClient("core", hostAddr, nil, false, time.Second*10)
 		}

--- a/provider.go
+++ b/provider.go
@@ -23,9 +23,10 @@ import (
 )
 
 const oldVersionWarning = `####################################################################
-WARNING: fleetctl (%s) is older than the latest registered
-version of fleet found in the cluster (%s). You are strongly
-recommended to upgrade fleetctl to prevent incompatibility issues.
+WARNING: The linked against fleet go lib (%s) is older than the latest
+registered version of fleet found in the cluster (%s). You are strongly
+recommended to upgrade the linked fleet go lib and rebuild to prevent
+incompatibility issues.
 ####################################################################
 `
 
@@ -153,7 +154,10 @@ func getAPI(driver string, driverEndpoint string, maxRetries int, etcdKeyPrefix 
 	case "etcd":
 		return getETCDClient(driverEndpoint, etcdKeyPrefix)
 	case "tunnel":
-		return getTunnelClient(driverEndpoint, maxRetries)
+		if len(driverEndpoint) > 0 {
+			return getTunnelClient(driverEndpoint, maxRetries)
+		}
+		fallthrough
 	case "null":
 		fallthrough
 	default:

--- a/provider.go
+++ b/provider.go
@@ -94,8 +94,8 @@ func getETCDClient(driverEndpoint string, etcdKeyPrefix string) (client.API, err
 		return nil, err
 	}
 
-	kAPI := etcd.NewKeysAPI(eClient)
-	reg := registry.NewEtcdRegistry(kAPI, etcdKeyPrefix, defaultTimeout)
+	keysAPI := etcd.NewKeysAPI(eClient)
+	reg := registry.NewEtcdRegistry(keysAPI, etcdKeyPrefix, defaultTimeout)
 
 	if msg, ok := checkVersion(reg); !ok {
 		log.Printf(msg)
@@ -125,7 +125,7 @@ func getTunnelClient(driverEndpoint string, tunnelEndpoint string, maxRetries in
 	// This is needed to fake out the client - it isn't used
 	// since we're overloading the dial method on the transport
 	// but the client complains if it isn't set
-	fakeHttpEndpoint, err := url.Parse("http://domain-sock")
+	fakeHTTPEndpoint, err := url.Parse("http://domain-sock")
 
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ func getTunnelClient(driverEndpoint string, tunnelEndpoint string, maxRetries in
 		Transport: &trans,
 	}
 
-	return client.NewHTTPClient(&httpClient, *fakeHttpEndpoint)
+	return client.NewHTTPClient(&httpClient, *fakeHTTPEndpoint)
 }
 
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -58,7 +58,7 @@ func TestGetAPI(test *testing.T) {
 	// when the address is an empty string, we get a nullAPI
 	var api client.API
 
-	api, err := getAPI("nothing", "non-http-endpoint", "", 1)
+	api, err := getAPI("nothing", "non-http-endpoint", "", 1, "")
 
 	if err != nil {
 		test.Fatal(err)

--- a/provider_test.go
+++ b/provider_test.go
@@ -58,7 +58,7 @@ func TestGetAPI(test *testing.T) {
 	// when the address is an empty string, we get a nullAPI
 	var api client.API
 
-	api, err := getAPI("nothing", "non-http-endpoint", "", 1, "")
+	api, err := getAPI("null", "endpoint", 1, "etcd_prefix")
 
 	if err != nil {
 		test.Fatal(err)

--- a/provider_test.go
+++ b/provider_test.go
@@ -58,7 +58,7 @@ func TestGetAPI(test *testing.T) {
 	// when the address is an empty string, we get a nullAPI
 	var api client.API
 
-	api, err := getAPI("", 1)
+	api, err := getAPI("nothing", "non-http-endpoint", "", 1)
 
 	if err != nil {
 		test.Fatal(err)

--- a/provider_test.go
+++ b/provider_test.go
@@ -58,7 +58,7 @@ func TestGetAPI(test *testing.T) {
 	// when the address is an empty string, we get a nullAPI
 	var api client.API
 
-	api, err := getAPI("null", "endpoint", 1, "etcd_prefix")
+	api, err := getAPI("null", "endpoint", 1, "etcd_prefix", "tunnel_address")
 
 	if err != nil {
 		test.Fatal(err)
@@ -76,7 +76,7 @@ func TestGetAPIEmptyEndpoint(test *testing.T) {
 	// when the address is an empty string, we get a nullAPI
 	var api client.API
 
-	api, err := getAPI("tunnel", "", 1, "etcd_prefix")
+	api, err := getAPI("tunnel", "", 1, "etcd_prefix", "tunnel_address")
 
 	if err != nil {
 		test.Fatal(err)

--- a/provider_test.go
+++ b/provider_test.go
@@ -71,3 +71,21 @@ func TestGetAPI(test *testing.T) {
 		test.Errorf("didn't get nullAPI, got %s instead", api)
 	}
 }
+
+func TestGetAPIEmptyEndpoint(test *testing.T) {
+	// when the address is an empty string, we get a nullAPI
+	var api client.API
+
+	api, err := getAPI("tunnel", "", 1, "etcd_prefix")
+
+	if err != nil {
+		test.Fatal(err)
+	}
+
+	switch api.(type) {
+	case nullAPI:
+		// pass!
+	default:
+		test.Errorf("didn't get nullAPI, got %s instead", api)
+	}
+}


### PR DESCRIPTION
I need update docs, just allows for creating an api client with an http endpoint without going through ssh.
